### PR TITLE
Updates TGMC links to use github pages

### DIFF
--- a/TGMC/BigRed/index.html
+++ b/TGMC/BigRed/index.html
@@ -35,8 +35,8 @@
 		webmap.attributionControl.setPrefix('SS13 WebMap by AffectedArc07');
 		webmap.options.minZoom = 4;
 		webmap.options.maxZoom = 6;
-		var image = L.imageOverlay('https://raw.githubusercontent.com/AffectedArc07/SS13WebMap-Images/master/TGMC/BigRed/BigRed_v2-1.png', bounds).addTo(webmap);
-		var pipenet = L.imageOverlay('https://raw.githubusercontent.com/AffectedArc07/SS13WebMap-Images/master/TGMC/BigRed/BigRed_v2-2.png', bounds).addTo(webmap);
+		var image = L.imageOverlay('https://AffectedArc07.github.io/SS13WebMap-Images/master/TGMC/BigRed/BigRed_v2-1.png', bounds).addTo(webmap);
+		var pipenet = L.imageOverlay('https://AffectedArc07.github.io/SS13WebMap-Images/master/TGMC/BigRed/BigRed_v2-2.png', bounds).addTo(webmap);
 		var base = {
 				"Base Map": image,
 			};

--- a/TGMC/IceColony/index.html
+++ b/TGMC/IceColony/index.html
@@ -35,8 +35,8 @@
 		webmap.attributionControl.setPrefix('SS13 WebMap by AffectedArc07');
 		webmap.options.minZoom = 4;
 		webmap.options.maxZoom = 6;
-		var image = L.imageOverlay('https://raw.githubusercontent.com/AffectedArc07/SS13WebMap-Images/master/TGMC/IceColony/Ice_Colony_v2-1.png', bounds).addTo(webmap);
-		var pipenet = L.imageOverlay('https://raw.githubusercontent.com/AffectedArc07/SS13WebMap-Images/master/TGMC/IceColony/Ice_Colony_v2-2.png', bounds).addTo(webmap);
+		var image = L.imageOverlay('https://AffectedArc07.github.io/SS13WebMap-Images/master/TGMC/IceColony/Ice_Colony_v2-1.png', bounds).addTo(webmap);
+		var pipenet = L.imageOverlay('https://AffectedArc07.github.io/SS13WebMap-Images/master/TGMC/IceColony/Ice_Colony_v2-2.png', bounds).addTo(webmap);
 		var base = {
 				"Base Map": image,
 			};

--- a/TGMC/LV624/index.html
+++ b/TGMC/LV624/index.html
@@ -35,8 +35,8 @@
 		webmap.attributionControl.setPrefix('SS13 WebMap by AffectedArc07');
 		webmap.options.minZoom = 4;
 		webmap.options.maxZoom = 6;
-		var image = L.imageOverlay('https://raw.githubusercontent.com/AffectedArc07/SS13WebMap-Images/master/TGMC/LV624/LV624-1.png', bounds).addTo(webmap);
-		var pipenet = L.imageOverlay('https://raw.githubusercontent.com/AffectedArc07/SS13WebMap-Images/master/TGMC/LV624/LV624-2.png', bounds).addTo(webmap);
+		var image = L.imageOverlay('https://AffectedArc07.github.io/SS13WebMap-Images/master/TGMC/LV624/LV624-1.png', bounds).addTo(webmap);
+		var pipenet = L.imageOverlay('https://AffectedArc07.github.io/SS13WebMap-Images/master/TGMC/LV624/LV624-2.png', bounds).addTo(webmap);
 		var base = {
 				"Base Map": image,
 			};

--- a/TGMC/PrisonStation/index.html
+++ b/TGMC/PrisonStation/index.html
@@ -35,8 +35,8 @@
 		webmap.attributionControl.setPrefix('SS13 WebMap by AffectedArc07');
 		webmap.options.minZoom = 4;
 		webmap.options.maxZoom = 6;
-		var image = L.imageOverlay('https://raw.githubusercontent.com/AffectedArc07/SS13WebMap-Images/master/TGMC/PrisonStation/Prison_Station_FOP-1.png', bounds).addTo(webmap);
-		var pipenet = L.imageOverlay('https://raw.githubusercontent.com/AffectedArc07/SS13WebMap-Images/master/TGMC/PrisonStation/Prison_Station_FOP-2.png', bounds).addTo(webmap);
+		var image = L.imageOverlay('https://AffectedArc07.github.io/SS13WebMap-Images/master/TGMC/PrisonStation/Prison_Station_FOP-1.png', bounds).addTo(webmap);
+		var pipenet = L.imageOverlay('https://AffectedArc07.github.io/SS13WebMap-Images/master/TGMC/PrisonStation/Prison_Station_FOP-2.png', bounds).addTo(webmap);
 		var base = {
 				"Base Map": image,
 			};

--- a/TGMC/Theseus/index.html
+++ b/TGMC/Theseus/index.html
@@ -35,8 +35,8 @@
 		webmap.attributionControl.setPrefix('SS13 WebMap by AffectedArc07');
 		webmap.options.minZoom = 4;
 		webmap.options.maxZoom = 6;
-		var image = L.imageOverlay('https://raw.githubusercontent.com/AffectedArc07/SS13WebMap-Images/master/TGMC/Theseus/TGS_Theseus-1.png', bounds).addTo(webmap);
-		var pipenet = L.imageOverlay('https://raw.githubusercontent.com/AffectedArc07/SS13WebMap-Images/master/TGMC/Theseus/TGS_Theseus-2.png', bounds).addTo(webmap);
+		var image = L.imageOverlay('https://AffectedArc07.github.io/SS13WebMap-Images/master/TGMC/Theseus/TGS_Theseus-1.png', bounds).addTo(webmap);
+		var pipenet = L.imageOverlay('https://AffectedArc07.github.io/SS13WebMap-Images/master/TGMC/Theseus/TGS_Theseus-2.png', bounds).addTo(webmap);
 		var base = {
 				"Base Map": image,
 			};


### PR DESCRIPTION
Github pages will need to be enabled on ss13webmap-images for this to work.
If you want to test it, you can instead swap it to `psykzz.github.io`.